### PR TITLE
fix: remove code execution from row parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Splunk, 2024-2025
+   Copyright (c) Splunk, 2024-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Splunk SOAR App: Google Sheets
+Copyright (c) Splunk, 2024-2026

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Google Sheets
 
-Publisher: Splunk Community \
-Connector Version: 1.0.1 \
-Product Vendor: Google \
-Product Name: Google Sheets \
+Publisher: Splunk Community <br>
+Connector Version: 1.0.1 <br>
+Product Vendor: Google <br>
+Product Name: Google Sheets <br>
 Minimum Product Version: 6.2.1
 
 This app allows various file manipulation actions to be performed on Google Sheets
@@ -78,15 +78,15 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[add new rows](#action-add-new-rows) - Use this action to add new rows to the sheet \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[add new rows](#action-add-new-rows) - Use this action to add new rows to the sheet <br>
 [create spreadsheet](#action-create-spreadsheet) - Create a new spreadsheet and share with users
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -101,7 +101,7 @@ No Output
 
 Use this action to add new rows to the sheet
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 This action can be used to append new rows to the sheet.
@@ -130,7 +130,7 @@ summary.total_objects_successful | numeric | | |
 
 Create a new spreadsheet and share with users
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 This action will create a new google sheet in the service account's root and share it with the users.
@@ -162,7 +162,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: _init_.py
 
-# Copyright (c) Splunk, 2024-2025
+# Copyright (c) Splunk, 2024-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googlesheets.json
+++ b/googlesheets.json
@@ -7,10 +7,10 @@
     "logo": "logo_googlesheets.svg",
     "logo_dark": "logo_googlesheets_dark.svg",
     "product_name": "Google Sheets",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk Community",
-    "license": "Copyright (c) Splunk, 2024-2025",
+    "license": "Copyright (c) Splunk, 2024-2026",
     "app_version": "1.0.1",
     "utctime_updated": "2024-06-11T03:16:46.151293Z",
     "package_name": "phantom_googlesheets",
@@ -245,12 +245,10 @@
             }
         ]
     },
-    "custom_made": true,
-    "copied_from_id": 189,
-    "copied_from_version": "3.5.0",
-    "directory": "googlesheets_37ed707d-109b-40b7-be61-d81868572473",
-    "version": 1,
-    "appname": "-",
-    "executable": "spawn3",
-    "disabled": false
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/googlesheets_connector.py
+++ b/googlesheets_connector.py
@@ -86,8 +86,11 @@ class GoogleSheetsConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
         sheet_id = param["google_sheet_id"]
         try:
-            rows = eval(param["rows"])
-        except Exception:
+            rows = json.loads(param["rows"])
+        except (TypeError, json.JSONDecodeError):
+            return RetVal(action_result.set_status(phantom.APP_ERROR, INVALID_ROW_DATA))
+
+        if not isinstance(rows, list) or not all(isinstance(row, list) for row in rows):
             return RetVal(action_result.set_status(phantom.APP_ERROR, INVALID_ROW_DATA))
 
         range_name = param["sheet_name"]

--- a/googlesheets_connector.py
+++ b/googlesheets_connector.py
@@ -1,6 +1,6 @@
 # File: googlesheets_connector.py
 
-# Copyright (c) Splunk, 2024-2025
+# Copyright (c) Splunk, 2024-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googlesheets_consts.py
+++ b/googlesheets_consts.py
@@ -1,6 +1,6 @@
 # File: googlesheets_consts.py
 
-# Copyright (c) Splunk, 2024-2025
+# Copyright (c) Splunk, 2024-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Parse new rows as JSON and reject values that are not a list of lists.


### PR DESCRIPTION
## Summary

- replace eval-based row parsing with strict JSON parsing
- require the parsed value to be a list of row lists
- refresh the connector build baseline on dev-cicd-tools v2.2.4 and Python 3.9/3.13

## Tracking

- PAPP-38191
- PSAAS-30609
- Parent epic: ESPM-5228

## Quality gate

- full local pre-commit suite passes, including static tests
- Python compilation passes

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38191
- PSAAS: PSAAS-30609
- Written by Codex.